### PR TITLE
docs: add AutoCon4 blog posts and session notes

### DIFF
--- a/docs/autocon_coverage/autocon4.md
+++ b/docs/autocon_coverage/autocon4.md
@@ -3,7 +3,9 @@
 A collection of links to AC4 related content.
 
 ## Blogs
-- Add a link your content!
+- [GeReader - What AutoCon4 Taught Me](https://blog.gereader.xyz/posts/autocon4/)
+- [GeReader - NautoCon and AutoCon4 Session Notes](https://blog.gereader.xyz/posts/autocon4-notes/)
+- Add a link to your content!
 
 ## Podcasts
 - Add a link to your content!


### PR DESCRIPTION
- Add What AutoCon4 Taught Me blog post link
- Add NautoCon and AutoCon4 Session Notes

Both links are publicly available resources on my blog. 
No structural changes, text only updates.