### PR TITLE
Add some blogs and LinkedIn posts about AC4

### DIFF
--- a/docs/autocon_coverage/autocon4.md
+++ b/docs/autocon_coverage/autocon4.md
@@ -3,7 +3,12 @@
 A collection of links to AC4 related content.
 
 ## Blogs
-- Add a link your content!
+- Justin Ryburn - [Autocon4: Keeping Automation Weird](https://ryburn.org/2025/11/30/autocon4-keeping-automation-weird/)
+- William Collins [Autocon4: Keeping Automation Weird in Austoin](https://www.itential.com/blog/company/ai-networking/autocon-4-keeping-automation-weird-in-austin/)
+- Bart Smeding - [LinkedIn Post](https://www.linkedin.com/posts/bartsmeding_autocon4-autocon-naf-activity-7398404979117490177-rPeA/)
+- Patrick Dobry - [LinkedIn Post](https://www.linkedin.com/posts/patrickdobry_networkautomation-autocon4-netdevops-activity-7399492830697553920-ym8t/)
+- Carl Buchman - [LinkedIn Post](https://www.linkedin.com/posts/carl-buchmann-6b436727_on-my-way-back-home-from-autocon4-and-reflecting-activity-7397780701380771840-CLrs/)
+- William Collins - [LinkedIn Post](https://www.linkedin.com/posts/william-collins_autocon4-supernerds-thecloudgambit-activity-7399094085782908928-ijWo/)
 
 ## Podcasts
 - Add a link to your content!


### PR DESCRIPTION
I kept the "full" blog posts at the top of the list with "mere" LI posts below.

Just a quick few I found.