### PR TITLE
fix: add *.pdf to LFS tracking in autocon_coverage

### DIFF
--- a/docs/autocon_coverage/.gitattributes
+++ b/docs/autocon_coverage/.gitattributes
@@ -1,1 +1,2 @@
+*.pdf filter=lfs diff=lfs merge=lfs -text
 *.pptx filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary

- `docs/autocon_coverage/.gitattributes` only tracked `*.pptx` but was missing `*.pdf`, causing PDF files to remain as LFS pointers instead of being checked out as actual files
- `AutoCon4/.gitattributes` already has both entries, but the parent directory was missing the `*.pdf` rule
- With this fix, PDF files are correctly smudged to their real content on checkout

## Test plan

- [ ] Run `git checkout HEAD -- docs/autocon_coverage/` and confirm PDF files expand to their actual size (several MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)